### PR TITLE
Adds VS2013 generated solution files to ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
+*.sln.ide/
 
 # Build results
 


### PR DESCRIPTION
VS2013 creates a .sln.ide folder and puts some generated files in there.  This adds the folder to the GIT ignore list so they don't get committed.
