### PR TITLE
Adds two tests of the buffer underrun exception.

### DIFF
--- a/src/kafka-tests/Unit/ProtocolMessageTests.cs
+++ b/src/kafka-tests/Unit/ProtocolMessageTests.cs
@@ -1,9 +1,11 @@
-﻿using System.Linq;
-using KafkaNet;
+﻿using System;
+using System.IO;
+using System.Linq;
+using kafka_tests.Helpers;
+using KafkaNet.Common;
 using KafkaNet.Protocol;
 using NUnit.Framework;
-using kafka_tests.Helpers;
-
+using Zoltu.IO;
 
 namespace kafka_tests.Unit
 {
@@ -68,6 +70,69 @@ namespace kafka_tests.Unit
             var result = Message.DecodeMessageSet(MessageHelper.FetchResponseMaxBytesOverflow).ToList();
 
             Assert.That(result.Count, Is.EqualTo(529));
+        }
+
+        [Test]
+        public void WhenMessageIsTruncatedThenBufferUnderRunExceptionIsThrown()
+        {
+            // arrange
+            var offset = (Int64)0;
+            var message = new Byte[] { };
+            var messageSize = message.Length + 1;
+            var memoryStream = new MemoryStream();
+            var binaryWriter = new BigEndianBinaryWriter(memoryStream);
+            binaryWriter.Write(offset);
+            binaryWriter.Write(messageSize);
+            binaryWriter.Write(message);
+            var payloadBytes = memoryStream.ToArray();
+
+            // act/assert
+            Assert.Throws<BufferUnderRunException>(() => Message.DecodeMessageSet(payloadBytes).ToList());
+        }
+
+        [Test]
+        public void WhenMessageIsExactlyTheSizeOfBufferThenMessageIsDecoded()
+        {
+            // arrange
+            var expectedPayloadBytes = new Byte[] { 1, 2, 3, 4 };
+            var payload = CreatePayload(0, 0, 0, new Byte[] { 0 }, expectedPayloadBytes);
+
+            // act/assert
+            var messages = Message.DecodeMessageSet(payload).ToList();
+            var actualPayload = messages.First().Value;
+
+            // assert
+            var expectedPayload = new Byte[] { 1, 2, 3, 4 };
+            CollectionAssert.AreEqual(expectedPayload, actualPayload);
+        }
+
+        private static Byte[] CreatePayload(Int64 offset, Byte magicByte, Byte attributes, Byte[] key, Byte[] payload)
+        {
+            var crcContentStream = new MemoryStream();
+            var crcContentWriter = new BigEndianBinaryWriter(crcContentStream);
+            crcContentWriter.Write(magicByte);
+            crcContentWriter.Write(attributes);
+            crcContentWriter.Write((Int32)key.Length);
+            crcContentWriter.Write(key);
+            crcContentWriter.Write(payload.Length);
+            crcContentWriter.Write(payload);
+            var crcContentBytes = crcContentStream.ToArray();
+
+            var crc = Crc32.Compute(crcContentBytes);
+
+            var messageStream = new MemoryStream();
+            var messageWriter = new BigEndianBinaryWriter(messageStream);
+            messageWriter.Write(crc);
+            messageWriter.Write(crcContentBytes);
+            var messageBytes = messageStream.ToArray();
+
+            var messageSetStream = new MemoryStream();
+            var messageSetWriter = new BigEndianBinaryWriter(messageSetStream);
+            var messageSize = messageBytes.Length;
+            messageSetWriter.Write(offset);
+            messageSetWriter.Write(messageSize);
+            messageSetWriter.Write(messageBytes);
+            return messageSetStream.ToArray();
         }
     }
 }

--- a/src/kafka-tests/kafka-tests.csproj
+++ b/src/kafka-tests/kafka-tests.csproj
@@ -58,6 +58,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="Zoltu.EndianAwareBinaryReaderWriter">
+      <HintPath>..\packages\Zoltu.EndianAwareBinaryReaderWriter.0.0.5.0\lib\net45\Zoltu.EndianAwareBinaryReaderWriter.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Fakes\BrokerRouterProxy.cs" />

--- a/src/kafka-tests/packages.config
+++ b/src/kafka-tests/packages.config
@@ -6,4 +6,5 @@
   <package id="Ninject.MockingKernel.Moq" version="3.0.0.5" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Zoltu.EndianAwareBinaryReaderWriter" version="0.0.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Note: Depends on PR #29.

This adds two tests of the buffer underrun behavior.  One of them currently _FAILS_ due to a bug in the implementation.  The bug is that the total MessageSet size is being compared against the expected message length.  The message set size includes already read parts of the payload such as the offset and the message size itself.

The quick fix would be to change `if (stream.Payload.Length < messageSize)` into `if (stream.Payload.Length - MessageHeaderSize < messageSize)`.
