### PR TITLE
Maximum reconnection timeout

### DIFF
--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -30,7 +30,7 @@ namespace TestHarness
 
             //create a producer to send messages with
             var producer = new Producer(new BrokerRouter(options));
-
+           
             Console.WriteLine("Type a message and press enter...");
             while (true)
             {
@@ -39,9 +39,10 @@ namespace TestHarness
                 if (string.IsNullOrEmpty(message))
                 {
                     //special case, send multi messages quickly
-                    for (int i = 0; i < 20; i++)
+                    for (int i = 0; i < 10; i++)
                     {
-                        producer.SendMessageAsync("TestHarness", new[] { new Message(i.ToString()) })
+                        producer
+                            .SendMessageAsync("TestHarness", new[] { new Message(i.ToString()) })
                             .ContinueWith(t =>
                             {
                                 t.Result.ForEach(x => Console.WriteLine("Complete: {0}, Offset: {1}", x.PartitionId, x.Offset));

--- a/src/kafka-net/BrokerRouter.cs
+++ b/src/kafka-net/BrokerRouter.cs
@@ -34,7 +34,7 @@ namespace KafkaNet
 
             foreach (var endpoint in _kafkaOptions.KafkaServerEndpoints)
             {
-                var conn = _kafkaOptions.KafkaConnectionFactory.Create(endpoint, _kafkaOptions.ResponseTimeoutMs, _kafkaOptions.Log);
+                var conn = _kafkaOptions.KafkaConnectionFactory.Create(endpoint, _kafkaOptions.ResponseTimeoutMs, _kafkaOptions.Log, _kafkaOptions.MaximumReconnectionTimeout);
                 _defaultConnectionIndex.AddOrUpdate(endpoint, e => conn, (e, c) => conn);
             }
 

--- a/src/kafka-net/Default/DefaultKafkaConnectionFactory.cs
+++ b/src/kafka-net/Default/DefaultKafkaConnectionFactory.cs
@@ -9,9 +9,9 @@ namespace KafkaNet
 {
     public class DefaultKafkaConnectionFactory : IKafkaConnectionFactory
     {
-        public IKafkaConnection Create(KafkaEndpoint endpoint, TimeSpan responseTimeoutMs, IKafkaLog log)
+        public IKafkaConnection Create(KafkaEndpoint endpoint, TimeSpan responseTimeoutMs, IKafkaLog log, int? maximumReconnectionTimeout = null)
         {
-            return new KafkaConnection(new KafkaTcpSocket(log, endpoint), responseTimeoutMs, log);
+            return new KafkaConnection(new KafkaTcpSocket(log, endpoint, maximumReconnectionTimeout), responseTimeoutMs, log);
         }
 
         public KafkaEndpoint Resolve(Uri kafkaAddress, IKafkaLog log)

--- a/src/kafka-net/Interfaces/IKafkaConnectionFactory.cs
+++ b/src/kafka-net/Interfaces/IKafkaConnectionFactory.cs
@@ -11,8 +11,9 @@ namespace KafkaNet
         /// <param name="endpoint">The specific KafkaEndpoint of the server to connect to.</param>
         /// <param name="responseTimeoutMs">The amount of time to wait for a message response to be received after sending a message to Kafka</param>
         /// <param name="log">Logging interface used to record any log messages created by the connection.</param>
+        /// <param name="maximumReconnectionTimeout"></param>
         /// <returns>IKafkaConnection initialized to connecto to the given endpoint.</returns>
-        IKafkaConnection Create(KafkaEndpoint endpoint, TimeSpan responseTimeoutMs, IKafkaLog log);
+        IKafkaConnection Create(KafkaEndpoint endpoint, TimeSpan responseTimeoutMs, IKafkaLog log, int? maximumReconnectionTimeout = null);
 
         /// <summary>
         /// Resolves a generic Uri into a uniquely identifiable KafkaEndpoint.

--- a/src/kafka-net/Interfaces/IKafkaRequest.cs
+++ b/src/kafka-net/Interfaces/IKafkaRequest.cs
@@ -11,6 +11,10 @@ namespace KafkaNet
     public interface IKafkaRequest<out T>
     {
         /// <summary>
+        /// Indicates this request should wait for a response from the broker
+        /// </summary>
+        bool ExpectResponse { get; }
+        /// <summary>
         /// Descriptive name used to identify the source of this request. 
         /// </summary>
         string ClientId { get; set; }

--- a/src/kafka-net/Model/KafkaOptions.cs
+++ b/src/kafka-net/Model/KafkaOptions.cs
@@ -52,6 +52,10 @@ namespace KafkaNet.Model
         /// Log object to record operational messages.
         /// </summary>
         public IKafkaLog Log { get; set; }
+        /// <summary>
+        /// Maximum reconnection timeout.
+        /// </summary>
+        public int? MaximumReconnectionTimeout { get; set; }
 
         public KafkaOptions(params Uri[] kafkaServerUri)
         {

--- a/src/kafka-net/Protocol/BaseRequest.cs
+++ b/src/kafka-net/Protocol/BaseRequest.cs
@@ -30,6 +30,11 @@ namespace KafkaNet.Protocol
         public int CorrelationId { get { return _correlationId; } set { _correlationId = value; } }
 
         /// <summary>
+        /// Flag which tells the broker call to expect a response for this request.
+        /// </summary>
+        public virtual bool ExpectResponse { get { return true; } }
+
+        /// <summary>
         /// Encode the common head for kafka request.
         /// </summary>
         /// <returns>KafkaMessagePacker with header populated</returns>

--- a/src/kafka-net/Protocol/ProduceRequest.cs
+++ b/src/kafka-net/Protocol/ProduceRequest.cs
@@ -8,10 +8,13 @@ namespace KafkaNet.Protocol
     public class ProduceRequest : BaseRequest, IKafkaRequest<ProduceResponse>
     {
         /// <summary>
+        /// Provide a hint to the broker call not to expect a response for requests without Acks.
+        /// </summary>
+        public override bool ExpectResponse { get { return Acks > 0; } }
+        /// <summary>
         /// Indicates the type of kafka encoding this request is.
         /// </summary>
         public ApiKeyRequestType ApiKey { get { return ApiKeyRequestType.Produce; } }
-
         /// <summary>
         /// Time kafka will wait for requested ack level before returning.
         /// </summary>

--- a/src/kafka-tests/Integration/ProducerIntegrationTests.cs
+++ b/src/kafka-tests/Integration/ProducerIntegrationTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using KafkaNet;
+using KafkaNet.Model;
+using KafkaNet.Protocol;
+using kafka_tests.Helpers;
+using NUnit.Framework;
+
+namespace kafka_tests.Integration
+{
+    [TestFixture]
+    [Category("Integration")]
+    public class ProducerIntegrationTests
+    {
+        [Test]
+        public void ProducerShouldNotExpectResponseWhenAckIsZero()
+        {
+            using (var router = new BrokerRouter(new KafkaOptions(IntegrationConfig.IntegrationUri)))
+            using (var producer = new Producer(router))
+            {
+                var sendTask = producer.SendMessageAsync(IntegrationConfig.IntegrationTopic, new[] { new Message(Guid.NewGuid().ToString()) }, acks:0);
+
+                sendTask.Wait(TimeSpan.FromHours(10));
+
+                Assert.That(sendTask.Status, Is.EqualTo(TaskStatus.RanToCompletion));
+            }
+        }
+    }
+}

--- a/src/kafka-tests/kafka-tests.csproj
+++ b/src/kafka-tests/kafka-tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Integration\KafkaMetadataProviderUnitTests.cs" />
     <Compile Include="Integration\OffsetManagementTests.cs" />
     <Compile Include="Integration\ProducerConsumerIntegrationTests.cs" />
+    <Compile Include="Integration\ProducerIntegrationTests.cs" />
     <Compile Include="Unit\BigEndianBinaryReaderTests.cs" />
     <Compile Include="Unit\BigEndianBinaryWriterTests.cs" />
     <Compile Include="Unit\FakeTcpServerTests.cs" />


### PR DESCRIPTION
Add support for setting maximum reconnection timeout.
The issue is that reconnecting to a broker doubles the time between reconnection forever, meaning at some point we could wait days to reconnect. It would be nice to allow setting the maximum time to wait between retries.
This pull request adds support for setting this value, but still allows the current way to do it, by not setting the value or setting the timeout to null.