### PR TITLE
Support version 0 (zookeeper) and version 1 (kafka) protocol for commit offsets.

### DIFF
--- a/src/kafka-net/Interfaces/IKafkaRequest.cs
+++ b/src/kafka-net/Interfaces/IKafkaRequest.cs
@@ -19,6 +19,10 @@ namespace KafkaNet
         /// </summary>
         string ClientId { get; set; }
         /// <summary>
+        /// The API Version used for this request
+        /// </summary>
+        short ApiVersion { get; }
+        /// <summary>
         /// Id which will be echoed back by Kafka to correlate responses to this request.  Usually automatically assigned by driver.
         /// </summary>
         int CorrelationId { get; set; }

--- a/src/kafka-net/Protocol/BaseRequest.cs
+++ b/src/kafka-net/Protocol/BaseRequest.cs
@@ -14,9 +14,14 @@ namespace KafkaNet.Protocol
         /// https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol
         /// </summary>
         protected const int ReplicaId = -1;
-        protected const Int16 ApiVersion = 0;
+        private readonly short _apiVersion;
         private string _clientId = "Kafka-Net";
         private int _correlationId = 1;
+
+        protected BaseRequest(short apiVersion = 0)
+        {
+            _apiVersion = apiVersion;
+        }
 
         /// <summary>
         /// Descriptive name of the source of the messages sent to kafka
@@ -28,6 +33,11 @@ namespace KafkaNet.Protocol
         /// It is useful for matching request and response between the client and server. 
         /// </summary>
         public int CorrelationId { get { return _correlationId; } set { _correlationId = value; } }
+
+        /// <summary>
+        /// Get the API Version for this request
+        /// </summary>
+        public short ApiVersion { get { return _apiVersion; } }
 
         /// <summary>
         /// Flag which tells the broker call to expect a response for this request.
@@ -43,7 +53,7 @@ namespace KafkaNet.Protocol
         {
             return new KafkaMessagePacker()
                  .Pack(((Int16)request.ApiKey))
-                 .Pack(ApiVersion)
+                 .Pack(request.ApiVersion)
                  .Pack(request.CorrelationId)
                  .Pack(request.ClientId, StringPrefixEncoding.Int16);
         }

--- a/src/kafka-net/Protocol/OffsetFetchRequest.cs
+++ b/src/kafka-net/Protocol/OffsetFetchRequest.cs
@@ -10,9 +10,14 @@ namespace KafkaNet.Protocol
     /// Class that represents both the request and the response from a kafka server of requesting a stored offset value
     /// for a given consumer group.  Essentially this part of the api allows a user to save/load a given offset position
     /// under any abritrary name.
+    /// This now supports version 1 of the protocol
     /// </summary>
     public class OffsetFetchRequest : BaseRequest, IKafkaRequest<OffsetFetchResponse>
     {
+        public OffsetFetchRequest(short version = 1) : base(version)
+        {
+
+        }
         public ApiKeyRequestType ApiKey { get { return ApiKeyRequestType.OffsetFetch; } }
         public string ConsumerGroup { get; set; }
         public List<OffsetFetch> Topics { get; set; }

--- a/src/kafka-tests/Integration/OffsetManagementTests.cs
+++ b/src/kafka-tests/Integration/OffsetManagementTests.cs
@@ -22,7 +22,7 @@ namespace kafka_tests.Integration
         }
 
         [Test]
-        public void OffsetFetchRequestOfNonExistingGroupShouldReturnNoError()
+        public void OffsetFetchRequestOfNonExistingGroupShouldReturnNoError([Values(0,1)] int version)
         {
             //From documentation: https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetFetchRequest
             //Note that if there is no offset associated with a topic-partition under that consumer group the broker does not set an error code 
@@ -30,27 +30,36 @@ namespace kafka_tests.Integration
             const int partitionId = 0;
             using (var router = new BrokerRouter(Options))
             {
-                var request = CreateOffsetFetchRequest(Guid.NewGuid().ToString(), partitionId);
+                var request = CreateOffsetFetchRequest(version, Guid.NewGuid().ToString(), partitionId);
 
                 var conn = router.SelectBrokerRoute(IntegrationConfig.IntegrationTopic, partitionId);
 
                 var response = conn.Connection.SendAsync(request).Result.FirstOrDefault();
 
                 Assert.That(response, Is.Not.Null);
-                Assert.That(response.Error, Is.EqualTo((int)ErrorResponseCode.NoError));
+                if (version == 0)
+                {
+                    // Version 0 (storing in zookeeper) results in unknown topic or partition as the consumer group
+                    // and partition are used to make up the string, and when it is missing it results in an error
+                    Assert.That(response.Error, Is.EqualTo((int)ErrorResponseCode.UnknownTopicOrPartition));
+                }
+                else
+                {
+                    Assert.That(response.Error, Is.EqualTo((int)ErrorResponseCode.NoError));
+                }
                 Assert.That(response.Offset, Is.EqualTo(-1));
             }
         }
 
         [Test]
-        public void OffsetCommitShouldStoreAndReturnSuccess()
+        public void OffsetCommitShouldStoreAndReturnSuccess([Values(0, 1)] int version)
         {
             const int partitionId = 0;
             using (var router = new BrokerRouter(Options))
             {
                 var conn = router.SelectBrokerRoute(IntegrationConfig.IntegrationTopic, partitionId);
 
-                var commit = CreateOffsetCommitRequest(IntegrationConfig.IntegrationConsumer, partitionId, 10);
+                var commit = CreateOffsetCommitRequest(version, IntegrationConfig.IntegrationConsumer, partitionId, 10);
                 var response = conn.Connection.SendAsync(commit).Result.FirstOrDefault();
 
                 Assert.That(response, Is.Not.Null);
@@ -59,7 +68,7 @@ namespace kafka_tests.Integration
         }
 
         [Test]
-        public void OffsetCommitShouldStoreOffsetValue()
+        public void OffsetCommitShouldStoreOffsetValue([Values(0, 1)] int version)
         {
             const int partitionId = 0;
             const long offset = 99;
@@ -69,13 +78,13 @@ namespace kafka_tests.Integration
 
                 var conn = router.SelectBrokerRoute(IntegrationConfig.IntegrationTopic, partitionId);
 
-                var commit = CreateOffsetCommitRequest(IntegrationConfig.IntegrationConsumer, partitionId, offset);
+                var commit = CreateOffsetCommitRequest(version, IntegrationConfig.IntegrationConsumer, partitionId, offset);
                 var commitResponse = conn.Connection.SendAsync(commit).Result.FirstOrDefault();
                 
                 Assert.That(commitResponse, Is.Not.Null);
                 Assert.That(commitResponse.Error, Is.EqualTo((int)ErrorResponseCode.NoError));
 
-                var fetch = CreateOffsetFetchRequest(IntegrationConfig.IntegrationConsumer, partitionId);
+                var fetch = CreateOffsetFetchRequest(version, IntegrationConfig.IntegrationConsumer, partitionId);
                 var fetchResponse = conn.Connection.SendAsync(fetch).Result.FirstOrDefault();
 
                 Assert.That(fetchResponse, Is.Not.Null);
@@ -85,8 +94,7 @@ namespace kafka_tests.Integration
         }
 
         [Test]
-        [Ignore("The response does not seem to return metadata information.  Not supported yet in kafka?")]
-        public void OffsetCommitShouldStoreMetadata()
+        public void OffsetCommitShouldStoreMetadata([Values(0, 1)] int version)
         {
             const int partitionId = 0;
             const long offset = 101;
@@ -96,24 +104,28 @@ namespace kafka_tests.Integration
             {
                 var conn = router.SelectBrokerRoute(IntegrationConfig.IntegrationTopic, partitionId);
 
-                var commit = CreateOffsetCommitRequest(IntegrationConfig.IntegrationConsumer, partitionId, offset, metadata);
+                var commit = CreateOffsetCommitRequest(version, IntegrationConfig.IntegrationConsumer, partitionId, offset, metadata);
                 var commitResponse = conn.Connection.SendAsync(commit).Result.FirstOrDefault();
 
                 Assert.That(commitResponse, Is.Not.Null);
                 Assert.That(commitResponse.Error, Is.EqualTo((int)ErrorResponseCode.NoError));
 
-                var fetch = CreateOffsetFetchRequest(IntegrationConfig.IntegrationConsumer, partitionId);
+                var fetch = CreateOffsetFetchRequest(version, IntegrationConfig.IntegrationConsumer, partitionId);
                 var fetchResponse = conn.Connection.SendAsync(fetch).Result.FirstOrDefault();
 
                 Assert.That(fetchResponse, Is.Not.Null);
                 Assert.That(fetchResponse.Error, Is.EqualTo((int)ErrorResponseCode.NoError));
                 Assert.That(fetchResponse.Offset, Is.EqualTo(offset));
-                Assert.That(fetchResponse.MetaData, Is.EqualTo(metadata));
+
+                // metadata is only stored with version 1. Zookeeper doesn't store metadata
+                if (version == 1)
+                {
+                    Assert.That(fetchResponse.MetaData, Is.EqualTo(metadata));
+                }
             }
         }
 
         [Test]
-        [Ignore("Not supported currently in 8.1.1?")]
         public void ConsumerMetadataRequestShouldReturnWithoutError()
         {
             using (var router = new BrokerRouter(Options))
@@ -129,9 +141,9 @@ namespace kafka_tests.Integration
             }
         }
 
-        private OffsetFetchRequest CreateOffsetFetchRequest(string consumerGroup, int partitionId)
+        private OffsetFetchRequest CreateOffsetFetchRequest(int version, string consumerGroup, int partitionId)
         {
-            var request = new OffsetFetchRequest
+            var request = new OffsetFetchRequest((short)version)
             {
                 ConsumerGroup = consumerGroup,
                 Topics = new List<OffsetFetch>
@@ -147,9 +159,9 @@ namespace kafka_tests.Integration
             return request;
         }
 
-        private OffsetCommitRequest CreateOffsetCommitRequest(string consumerGroup, int partitionId, long offset, string metadata = null)
+        private OffsetCommitRequest CreateOffsetCommitRequest(int version, string consumerGroup, int partitionId, long offset, string metadata = null)
         {
-            var commit = new OffsetCommitRequest
+            var commit = new OffsetCommitRequest((short)version)
             {
                 ConsumerGroup = consumerGroup,
                 OffsetCommits = new List<OffsetCommit>


### PR DESCRIPTION
Basic support working and unit tests running ok.

One unit test fails though - ProducerConsumerIntegrationTests - ConsumerShouldMoveToNextAvailableOffsetwhenQueryingForNextMessage is failing, but I don't think this is related.