### PR TITLE
This is to address the issues with requests not timing out when the kafk...

### DIFF
--- a/src/kafka-net/KafkaConnection.cs
+++ b/src/kafka-net/KafkaConnection.cs
@@ -99,7 +99,7 @@ namespace KafkaNet
                 if (_requestIndex.TryAdd(request.CorrelationId, asyncRequest) == false)
                     throw new ApplicationException("Failed to register request for async response.");
 
-                await SendAsync(request.Encode()).ConfigureAwait(false);
+                SendAsync(request.Encode());
 
                 var response = await asyncRequest.ReceiveTask.Task.ConfigureAwait(false);
 


### PR DESCRIPTION
This is to address the issues with requests not timing out when the kafka end point is not available. Since we  indefinitely try to reconnect to the endpoint, the await SendAsync is never returned and we do not get to observe the timeout exception on the asyncRequest.RecieveTask which could've timed already. In the real life scenario, the caller should be aware of the endpoint being down via timeout exception, not just await on it indefinitely.
