### PR TITLE
Make ExpectResponse return true for all replica acks

### DIFF
--- a/src/kafka-net/Protocol/ProduceRequest.cs
+++ b/src/kafka-net/Protocol/ProduceRequest.cs
@@ -10,7 +10,7 @@ namespace KafkaNet.Protocol
         /// <summary>
         /// Provide a hint to the broker call not to expect a response for requests without Acks.
         /// </summary>
-        public override bool ExpectResponse { get { return Acks > 0; } }
+        public override bool ExpectResponse { get { return Acks != 0; } }
         /// <summary>
         /// Indicates the type of kafka encoding this request is.
         /// </summary>


### PR DESCRIPTION
ExpectResponse of ProduceRequest was returning false when acks were being requested from all replicas. It will now also return true when a value of -1 is set (or in fact, any value other than zero).