### PR TITLE
correctly handle consumer maxwait timeouts over 31 bits in milliseconds

### DIFF
--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -140,7 +140,7 @@ namespace KafkaNet
 
                             var fetchRequest = new FetchRequest
                                 {
-                                    MaxWaitTime = (int)_options.MaxWaitTimeForMinimumBytes.TotalMilliseconds,
+                                    MaxWaitTime = (int)Math.Min((long)int.MaxValue, _options.MaxWaitTimeForMinimumBytes.TotalMilliseconds),
                                     MinBytes = _options.MinimumBytes,
                                     Fetches = fetches
                                 };


### PR DESCRIPTION
Timeout in milliseconds is silently downcast to signed integer causing usage of Timeout.MaxValue to result in a negative timeout.  This fix has no effect for values below 31 bits, and caps everything else to the 31 bit maximum.