### PR TITLE
Async consumer

### DIFF
--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -173,8 +173,8 @@ namespace KafkaNet
                                 }
                             }
 
-                            //no message received from server wait a while before we try another long poll
-                            Thread.Sleep(_options.BackoffInterval);
+							//no message received from server wait a while before we try another long poll
+	                        await Task.Delay(_options.BackoffInterval);
                         }
                         catch (BufferUnderRunException ex)
                         {

--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -105,18 +105,9 @@ namespace KafkaNet
                 tcs.SetCanceled();
                 return await tcs.Task;
             }
-            try
-            {
-                var result = (await _fetchResponseCollection.TakeAsync(1, timeout, token)).Single();
-                _boundedCapacitySemaphore.Release();
-                return result;
-            }
-            catch (Exception e)
-            {
-                var tcs = new TaskCompletionSource<Message>();
-                tcs.SetException(e);
-                return await tcs.Task;
-            }
+            var result = (await _fetchResponseCollection.TakeAsync(1, timeout, token)).Single();
+            _boundedCapacitySemaphore.Release();
+            return result;
         }
 
         /// <summary>

--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -54,6 +54,12 @@ namespace KafkaNet
         {
             _options.Log.DebugFormat("Consumer: Beginning consumption of topic: {0}", _options.Topic);
             EnsurePartitionPollingThreads();
+            // need a separate method with yield, otherwise EnsurePartitionPollingThreads() is not called until enumeration, e.g. ToArray()
+            return DoConsume(cancellationToken);
+        }
+
+        private IEnumerable<Message> DoConsume(CancellationToken? cancellationToken = null)
+        {
             while (true)
             {
                 try
@@ -79,8 +85,14 @@ namespace KafkaNet
             }
         }
 
+
+        public async Task<Message> ConsumeNextAsync()
+        {
+            return await ConsumeNextAsync(new TimeSpan(int.MaxValue), CancellationToken.None);
+        }
+
         /// <summary>
-        /// Pull next message for consumption asynchronously
+        /// Pull a next message for consumption asynchronously
         /// </summary>
         public async Task<Message> ConsumeNextAsync(TimeSpan timeout, CancellationToken token)
         {


### PR DESCRIPTION
This is a very simple implementation of #15 using AsyncCollection that was already in the project. It is a question/continuous discussion of #15 rather than a direct request to merge. I am not sure that this makes consumer non-blocking at a deeper level than just removing BlockingCollection, but the `ConsumeTopicPartitionAsync` method is already async and it looks like there is no other blocking methods. This keeps existing API unchanged, all tests pass.

I have noticed #23 very late.
