### PR TITLE
Remove ms from timeout exception message

### DIFF
--- a/src/kafka-net/KafkaConnection.cs
+++ b/src/kafka-net/KafkaConnection.cs
@@ -236,7 +236,7 @@ namespace KafkaNet
             else
             {
                 asyncRequestItem.ReceiveTask.TrySetException(new ResponseTimeoutException(
-                    string.Format("Timeout Expired. Client failed to receive a response from server after waiting {0}ms.",
+                    string.Format("Timeout Expired. Client failed to receive a response from server after waiting {0}.",
                         _responseTimeoutMS)));
             }
         }


### PR DESCRIPTION
The timeout is a TimeSpan making it unnecessary to write "ms" after the timespan