### PR TITLE
Hotfix/set offset bug

### DIFF
--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -166,7 +166,7 @@ namespace KafkaNet
                                     }
 
                                     var nextOffset = response.Messages.Max(x => x.Meta.Offset) + 1;
-                                    _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(nextOffset, false), (i, l) => l.Item2 ? l : new Tuple<long, bool>(nextOffset, false));
+                                    _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(nextOffset, false), (i, l) => l.Item2 ? new Tuple<long, bool>(l.Item1, false) : new Tuple<long, bool>(nextOffset, false));
 
                                     // sleep is not needed if responses were received
                                     continue;

--- a/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
+++ b/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
@@ -88,10 +88,8 @@ namespace kafka_tests.Integration
 
                 using (var consumer = new Consumer(new ConsumerOptions(IntegrationConfig.IntegrationTopic, router), offsets))
                 {
-                    for (int i = 0; i < 200; i++)
-                    {
-                        producer.SendMessageAsync(IntegrationConfig.IntegrationTopic, new[] { new Message(i.ToString(), testId) }).Wait();
-                    }
+                    int iter = 0;
+                    producer.SendMessageAsync(IntegrationConfig.IntegrationTopic, new int[1000].Select(i => new Message(iter++.ToString(), testId))).Wait();
 
                     var sentMessages = consumer.Consume().Take(20).ToList();
 


### PR DESCRIPTION
In a situation where the consumer class is able to fetch messages faster from a Kafka partition than the messages can be processed, setting the partition offset is ignored.

In the Consumer.ConsumeTopicPartitionAsync method the offset is retrieved in the beginning of the while loop and used afterwards. When handling the response and adding the messages to the _fetchResponseQueue, the task may block if the queue is full. 

If the client of the consumer class sets the offset while the consumer is blocked waiting for free space in the _fetchResponseQueue, the consumer class will override the offset after having added all current messages to the queue.

```
foreach (var message in response.Messages)
{
	_fetchResponseQueue.Add(message, _disposeToken.Token); <-- While blocking, if offset is set with a call to the SetOffsetPosition method, it will be overwritten later

	if (_disposeToken.IsCancellationRequested) return;
}

var nextOffset = response.Messages.Max(x => x.Meta.Offset) + 1;
_partitionOffsetIndex.AddOrUpdate(partitionId, i => nextOffset, (i, l) => nextOffset); <-- Offset is overwritten here
```



