### PR TITLE
Hotfix/set offset bug

### DIFF
--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -166,7 +166,7 @@ namespace KafkaNet
                                     }
 
                                     var nextOffset = response.Messages.Max(x => x.Meta.Offset) + 1;
-                                    _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(nextOffset, false), (i, l) => l.Item2 ? l : new Tuple<long, bool>(nextOffset, false));
+                                    _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(nextOffset, false), (i, l) => l.Item2 ? new Tuple<long, bool>(l.Item1, false) : new Tuple<long, bool>(nextOffset, false));
 
                                     // sleep is not needed if responses were received
                                     continue;

--- a/src/kafka-net/Consumer.cs
+++ b/src/kafka-net/Consumer.cs
@@ -125,7 +125,7 @@ namespace KafkaNet
                         {
                             //get the current offset, or default to zero if not there.
                             long offset = 0;
-                            _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(offset, false), (i, currentOffset) => { offset = currentOffset.Item1; return currentOffset; });
+                            _partitionOffsetIndex.AddOrUpdate(partitionId, i => new Tuple<long, bool>(offset, false), (i, currentOffset) => { offset = currentOffset.Item1; return new Tuple<long, bool>(currentOffset.Item1, false); });
 
                             //build a fetch request for partition at offset
                             var fetch = new Fetch

--- a/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
+++ b/src/kafka-tests/Integration/ProducerConsumerIntegrationTests.cs
@@ -88,10 +88,8 @@ namespace kafka_tests.Integration
 
                 using (var consumer = new Consumer(new ConsumerOptions(IntegrationConfig.IntegrationTopic, router), offsets))
                 {
-                    for (int i = 0; i < 200; i++)
-                    {
-                        producer.SendMessageAsync(IntegrationConfig.IntegrationTopic, new[] { new Message(i.ToString(), testId) }).Wait();
-                    }
+                    int iter = 0;
+                    producer.SendMessageAsync(IntegrationConfig.IntegrationTopic, new int[1000].Select(i => new Message(iter++.ToString(), testId))).Wait();
 
                     var sentMessages = consumer.Consume().Take(20).ToList();
 


### PR DESCRIPTION
There is a bug in the consumer class that makes it impossible to set partition offset if the consumer is under load.

```
foreach (var message in response.Messages)
   {
      _fetchResponseQueue.Add(message, _disposeToken.Token);    <-- Will block if queue is full

      if (_disposeToken.IsCancellationRequested) return;
   }

var nextOffset = response.Messages.Max(x => x.Meta.Offset) + 1;
_partitionOffsetIndex.AddOrUpdate(partitionId, i => nextOffset, (i, l) => nextOffset);   <-- Will overwrite any offset set by client while blocking above
```

I have changed the offset collection to include a boolean that indicates if the offset was set from outside the worker task.