### PR TITLE
fix bug: when utf 8 multibyte character, ToIntSizedBytes and ToInt16SizedBytes will get a wrong length.

### DIFF
--- a/src/kafka-net/Common/Extensions.cs
+++ b/src/kafka-net/Common/Extensions.cs
@@ -16,8 +16,10 @@ namespace KafkaNet.Common
         {
             if (string.IsNullOrEmpty(value)) return (-1).ToBytes();
 
-            return value.Length.ToBytes()
-                        .Concat(value.ToBytes())
+            var bytes = value.ToBytes();
+
+            return bytes.Length.ToBytes()
+                        .Concat(bytes)
                         .ToArray();
         }
 
@@ -25,8 +27,10 @@ namespace KafkaNet.Common
         {
             if (string.IsNullOrEmpty(value)) return (-1).ToBytes();
 
-            return ((Int16)value.Length).ToBytes()
-                        .Concat(value.ToBytes())
+            var bytes = value.ToBytes();
+
+            return ((Int16)bytes.Length).ToBytes()
+                        .Concat(bytes)
                         .ToArray();
         }
 


### PR DESCRIPTION
KafkaNet.Common.Extensions  public static byte[] ToIntSizedBytes(this string value) and public static byte[] ToInt16SizedBytes(this string value)
These kafka STRING should use the bytes length, not string length. When we use UTF8 encode the none-ascii characters such as Chinese, the "string.Length" is the number of characters, not the real byte length.

reffer:
http://kafka.apache.org/protocol.html#protocol_types
https://msdn.microsoft.com/en-us/library/system.strings(v=vs.110).aspx
